### PR TITLE
Add PromptEden to Agent Evaluation & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@
 - [LMArena (formerly LMSYS Chatbot Arena)](https://lmarena.ai/) - 🆕 Crowdsourced LLM benchmark using human preference voting. LMSYS rebranded to LMArena in 2025.
 - [Patronus AI](https://www.patronus.ai/) - 🆕 Automated LLM evaluation and red-teaming platform.
 - [BenchClaw](https://github.com/Agnuxo1/benchclaw) - 🆕 Multi-dimensional AI agent evaluation harness — 17-judge tribunal, 8 deception detectors, 10 scoring dimensions. Connect any LLM agent for scientific benchmarking. ![GitHub stars](https://img.shields.io/github/stars/Agnuxo1/benchclaw?style=flat-square)
+- [PromptEden](https://www.prompteden.com) - External AI-visibility monitoring — tracks how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand and which competitors they recommend instead, refreshed daily across 9+ platforms.
 
 ---
 


### PR DESCRIPTION
Adds [PromptEden](https://www.prompteden.com) to **📊 Agent Evaluation & Observability**.

PromptEden monitors how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand — and which competitors they recommend instead. Daily refresh across 9+ AI platforms; surfaces visibility scores, citation sources, and competitor mentions.

Sits next to the internal-app monitoring tools in this section (Helicone, Arize Phoenix, Langfuse) as the externally-facing complement: those instrument your own LLM apps; PromptEden instruments how public LLM assistants describe brands. Same observability discipline, different surface.