### PR TITLE
feat: add Dakera to Agent Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 - [LangGraph Memory](https://github.com/langchain-ai/langgraph) - 🆕 Built-in persistence and checkpointing for stateful agent workflows. ![GitHub stars](https://img.shields.io/github/stars/langchain-ai/langgraph?style=flat-square)
 - [Graphiti](https://github.com/getzep/graphiti) - 🆕 Build and query knowledge graphs for agent memory using temporal awareness. ![GitHub stars](https://img.shields.io/github/stars/getzep/graphiti?style=flat-square)
 - [Claude Managed Agents Memory](https://platform.claude.com/docs/en/release-notes/overview) - 🆕 **April 23, 2026** (public beta). Anthropic's persistent memory feature for Claude Managed Agents. Agents retain information across sessions by mounting read/write memory stores to a filesystem. Enables long-running agents to learn and adapt without resetting context.
+- [Dakera](https://github.com/Dakera-AI/dakera-mcp) - Persistent, decay-weighted vector memory MCP server for AI agents. 83 MCP tools for store, recall, hybrid BM25+vector search, knowledge graphs, and cross-agent memory sharing. Built in Rust. ![GitHub stars](https://img.shields.io/github/stars/Dakera-AI/dakera-mcp?style=flat-square)
 
 ## 🔌 Tool & API Integration
 


### PR DESCRIPTION
## Add Dakera — Persistent Decay-Weighted Vector Memory MCP Server

**Dakera** is a production-grade AI agent memory server with 83 MCP tools.

- **Repo:** https://github.com/Dakera-AI/dakera-mcp
- **Category:** Agent Memory

**Unique differentiator:** Decay-weighted importance scoring — memories fade naturally unless accessed, so the most-relevant memories surface first. This is built into the memory primitive rather than requiring application-level staleness management.

**Key capabilities:**
- 83 MCP tools (store, recall, hybrid BM25+vector search, knowledge graphs, cross-agent memory sharing)
- ONNX embeddings bundled — zero external model dependencies
- Session-scoped isolation for multi-agent systems
- Built in Rust — production-grade performance
- Self-hosted: `cargo install dakera-mcp` or Docker

Added at the end of the Agent Memory section (after Claude Managed Agents Memory).