### PR TITLE
Add AI for Database — natural language database agent with dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 - [LightRAG](https://github.com/HKUDS/LightRAG) - 🆕 Simple and fast RAG engine with graph-based knowledge indexing. ![GitHub stars](https://img.shields.io/github/stars/HKUDS/LightRAG?style=flat-square)
 - [R2R](https://github.com/SciPhi-AI/R2R) - 🆕 Production-ready RAG engine with built-in auth, observability, and ingestion. ![GitHub stars](https://img.shields.io/github/stars/SciPhi-AI/R2R?style=flat-square)
 - [Vanna](https://github.com/vanna-ai/vanna) - 📦 **Archived** (2026-02). RAG for SQL — chat with your database using natural language. ![GitHub stars](https://img.shields.io/github/stars/vanna-ai/vanna?style=flat-square)
+- [AI for Database](https://aifordatabase.com) - ⚠️ Unverified. Agentic platform for natural language database queries — no SQL needed — plus self-refreshing dashboards and data-triggered workflows.
 
 ## 💻 Coding Agents
 


### PR DESCRIPTION
## What is AI for Database?

[AI for Database](https://aifordatabase.com) is an agentic platform that connects to any database and lets you interact with it in plain English — no SQL required.

**Key features:**
- Natural language database queries (no SQL)
- Self-refreshing intelligent dashboards
- AI-powered action workflows (trigger emails, webhooks, alerts on data changes)
- Multi-database support (PostgreSQL, MySQL, MongoDB, etc.)

I added it to the **RAG & Knowledge** section, right after the archived Vanna entry, since it is essentially the active, production-ready successor addressing the same use case (chat with your database using natural language).

## Checklist
- [x] Tool is publicly available at https://aifordatabase.com
- [x] Description is one sentence, factual, no marketing language
- [x] Tagged as `⚠️ Unverified` per contribution guidelines
- [x] Placed in alphabetical-ish position near similar tools