### PR TITLE
Add Bernstein to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 - [Lindy](https://www.lindy.ai/) - 🆕 Top no-code agent framework for business users with visual workflow builder.
 - [Octomind](https://github.com/muvon/octomind) - 🆕 Rust-based open-source AI agent runtime. Model-agnostic (13+ providers), community-built specialist agents (developer, medical, legal, DevOps), MCP support with runtime self-extension, zero-config setup. Apache 2.0. ![GitHub stars](https://img.shields.io/github/stars/muvon/octomind?style=flat-square)
 - [Microsoft AI Agent Governance Toolkit](https://www.helpnetsecurity.com/2026/04/03/microsoft-ai-agent-governance-toolkit/) - 🆕 **April 3, 2026**. Open-source toolkit for enforcing runtime security policies across agent frameworks including LangChain and AutoGen. Policy-as-code approach for enterprise AI governance.
+- [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - 🆕 Python orchestrator for 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider). One LLM plan call up front; scheduling, git worktree isolation, quality gates, and HMAC-chained audit are deterministic. Apache-2.0. ![GitHub stars](https://img.shields.io/github/stars/sipyourdrink-ltd/bernstein?style=flat-square)
 
 ---
 


### PR DESCRIPTION
Adds Bernstein to the Agent Frameworks section.

- Repo: https://github.com/sipyourdrink-ltd/bernstein
- License: Apache-2.0
- 350 stars (above the 100-star quality gate), on PyPI as \`bernstein\`.
- Python orchestrator for 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider). One LLM plan call up front; after that, scheduling, git worktree isolation per task, quality gates, and an HMAC-chained audit log are deterministic Python.
- Already listed on vinta/awesome-python, jim-schwoebel/awesome_ai_agents, bradAGI/awesome-cli-coding-agents, punkpeye/awesome-mcp-servers — verifiable third-party traction.

One-sentence factual description, no marketing copy. Canonical repo link.

Maintainer disclosure: I am the maintainer.