### PR TITLE
Add taOSmd (local-first, benchmarked agent memory on a full transcript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 - [LangGraph Memory](https://github.com/langchain-ai/langgraph) - 🆕 Built-in persistence and checkpointing for stateful agent workflows. ![GitHub stars](https://img.shields.io/github/stars/langchain-ai/langgraph?style=flat-square)
 - [Graphiti](https://github.com/getzep/graphiti) - 🆕 Build and query knowledge graphs for agent memory using temporal awareness. ![GitHub stars](https://img.shields.io/github/stars/getzep/graphiti?style=flat-square)
 - [Claude Managed Agents Memory](https://platform.claude.com/docs/en/release-notes/overview) - 🆕 **April 23, 2026** (public beta). Anthropic's persistent memory feature for Claude Managed Agents. Agents retain information across sessions by mounting read/write memory stores to a filesystem. Enables long-running agents to learn and adapt without resetting context.
+- [taOSmd](https://github.com/jaylfc/taosmd) - Local-first, benchmarked agent memory on an append-only transcript: typed temporal knowledge graph where corrected facts supersede old ones, plus hybrid vector + BM25 retrieval. Tuned for small local models, fully offline (runs on an 8GB Pi); 97% on LongMemEval-S. ![GitHub stars](https://img.shields.io/github/stars/jaylfc/taosmd?style=flat-square)
 
 ## 🔌 Tool & API Integration
 


### PR DESCRIPTION
Adds **taOSmd** (https://github.com/jaylfc/taosmd), a local-first, offline agent memory system, to the list, following the existing entry format in this section.

What it is: an append-only, read-only transcript (user + agent messages, tool calls and results, decisions, errors) that a librarian derives a typed temporal knowledge graph and vector memory from. Corrected facts supersede old ones via invalidation (recall returns only the active fact). Hybrid vector + BM25 retrieval, tuned to run on small local models, fully offline (8GB RAM, no API keys). Benchmarked: 97.0% end-to-end Judge on LongMemEval-S and a same-tier leader result on LoCoMo (methodology in docs/benchmarks.md).

Open source (Python API + CLI today; MCP and a local HTTP API are work in progress). Happy to adjust placement, wording, or fields to match your conventions.