### PR TITLE
Add AgentServices — x402-paid data APIs with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,8 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 
 - [mcp-agent](https://github.com/lastmile-ai/mcp-agent) - 🆕 Open-source Python framework designed with Model Context Protocol (MCP) as its core communication primitive for building agents natively interoperable with the MCP tool ecosystem. ![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Flastmile-ai%2Fmcp-agent&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
 
+- [AgentServices](https://agentservices.to) - 🆕 Paid data APIs for AI agents with x402 on-chain payments — 54 services covering crypto market data, financial intelligence, onchain analytics, and inference. MCP server with 37 tools. Agents pay per-call in USDC on Base via HTTP 402.
+
 ## 🧪 Agent Sandboxing & Compute Isolation
 
 *Secure runtimes that let agents execute generated code and shell commands without compromising the host. Critical infrastructure once you let an agent off the leash.*


### PR DESCRIPTION
## What
Adding **AgentServices** — a production x402-paid data API platform for AI agents — to the Tool & API Integration section.

## Project details
- **Name:** AgentServices
- **URL:** https://agentservices.to
- **MCP server:** https://agentservices.to/mcp
- **Section:** Tool & API Integration

## What it does
AgentServices provides 54 data services (crypto market data, financial intelligence, onchain analytics, inference) behind a single MCP server with 37 tools. AI agents pay per-call via the x402 protocol — HTTP 402 responses trigger USDC micropayments on Base (Layer 2). Gasless payments via CDP paymaster.

## Why it belongs here
AgentServices is directly built for the agent ecosystem:
- **MCP-native**: full MCP server with 37 tools, listed on the official MCP Registry (`to.agentservices/agentservices`)
- **x402 payments**: first production platform using HTTP 402 for agent-to-API micropayments
- **Agent-tested**: agents using Claude, Cursor, and Coinbase AgentKit can discover and pay for data autonomously
- **Live and operational**: first on-chain x402 payment triggered July 2026

It fits the Tool & API Integration section alongside Composio, Toolhouse, and other agent-API integration platforms, with the distinction of being the first x402-paid entry.