### PR TITLE
Add TranslateScan to AI tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 
 ---
 
+- [TranslateScan](https://translatescan.com) - AI translator for scanned PDFs, photos, and documents preserving original layout.
 ## 🔗 Agent Protocols & Standards
 
 *Open standards enabling agent interoperability, tool access, and cross-platform communication.*


### PR DESCRIPTION
Tool Name: TranslateScan
URL: https://translatescan.com
Category: AI Translation
Description: AI translator for scanned PDFs and photos preserving original layout