### PR TITLE
Add Resume Roaster (AI resume critique) to Personal & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,6 +1224,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 - [Coze (扣子)](https://www.coze.cn/) - ByteDance's no-code agent builder. Mainland-only consumer surface; international counterpart is coze.com.
 - [Qwen App (千问)](https://www.qwen.ai/) - Alibaba's mass-market consumer agent (rebranded from Tongyi Qianwen), integrated across Taobao / DingTalk / Quark.
 - [Doubao Agents](https://www.doubao.com/) - ByteDance's flagship consumer assistant on top of the Doubao model family.
+- [Resume Roaster](https://resume.roastlabai.com/) - AI-powered resume critique with ATS keyword gap analysis. Upload your resume and any job description to get specific AI feedback on what to improve before applying. Built for job seekers wanting edge in competitive markets.
 
 ### Developer Tools
 


### PR DESCRIPTION
## What this adds

[Resume Roaster](https://resume.roastlabai.com/) - an AI-powered productivity tool for job seekers.

Fits the **Personal & Productivity** section because it's an AI agent use case for career advancement:
- Upload resume + job description
- AI analyzes keyword gaps, ATS compatibility, and gives direct improvement feedback
- Helps users act faster and smarter in competitive hiring pipelines

**Live:** https://resume.roastlabai.com
**Pricing:** Freemium (free AI critique on signup)

Happy to adjust the description or suggest a better section if this doesn't fit!