### PR TITLE
Add agent-qa to Browser and Web Agents

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -982,6 +982,7 @@
 
 *実ブラウザを介して Web と対話するエージェント—— ナビゲーション、クリック、スクレイピング、マルチページワークフローをこなすフレームワークとインフラ。*
 
+- [agent-qa](https://github.com/vostride/agent-qa) - 自然言語で記述した Web・モバイルテストを実行し、UI 操作を自己修復しながら過去の実行から学習する、オープンソースの自己改善型 QA エージェント。![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fvostride%2Fagent-qa&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
 - [Cloudflare Kitesurf](https://blog.cloudflare.com/kitesurf/) - 🆕 ⚡ **2026年8月6日（ベータ、Cloudflare Agents Week）**。Cloudflare が AI エージェント専用に設計したサーバーレスブラウザ。Workers 上で動作し、セッションごとに独立・ステートレスで、ピクセル完璧なレンダリングよりもトークン効率と低リソース消費を優先。Puppeteer と Playwright をサポート；スクリーンショットワークロードで **Chromium 比 CPU 3.1 分の 1・メモリ 4.7 分の 1**、Web Platform Tests 21.5 万件超をパス。ベータ期間中は Browser Rendering 経由で無料。制限：動画再生・WebGL・永続認証は非対応。
 - [Browser Use](https://github.com/browser-use/browser-use) - **v0.13.7（2026年7月27日）**。Web サイトを AI エージェントから利用可能にするブラウザ自動化。2026 年にオープンソースブラウザエージェントの事実上の標準。109K+ star。![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fbrowser-use%2Fbrowser-use&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
 - [Stagehand](https://github.com/browserbase/stagehand) - Browserbase 製の「ブラウザエージェント用 SDK」—— 型付きの `act` / `extract` / `observe` プリミティブを Playwright の上に提供。MIT。![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fbrowserbase%2Fstagehand&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
@@ -2012,4 +2013,3 @@ MIT © [Zijian Ni](https://github.com/Zijian-Ni)
 ---
 
 *Made with ❤️ by [Zijian Ni](https://github.com/Zijian-Ni) · 2026。日本語版は英語版と同期します。不一致がある場合は英語版を正とします。*
-

--- a/README.md
+++ b/README.md
@@ -974,6 +974,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 
 *Frameworks and infrastructure for agents that interact with the web through real browsers — navigate, click, scrape, and complete multi-page workflows.*
 
+- [agent-qa](https://github.com/vostride/agent-qa) - Open-source self-improving QA agent that runs natural-language web and mobile tests, self-heals UI interactions, and learns from previous runs. ![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fvostride%2Fagent-qa&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
 - [Cloudflare Kitesurf](https://blog.cloudflare.com/kitesurf/) - 🆕 ⚡ **August 6, 2026 (beta, Cloudflare Agents Week)**. Cloudflare's new serverless browser built specifically for AI agents — runs on Workers, stateless and isolated per session, optimized for token count and context-window efficiency over pixel-perfect rendering. Supports Puppeteer and Playwright; **3.1× less CPU and 4.7× less memory than Chromium** for screenshot workloads, 215K+ Web Platform Tests passing. Free during beta via Browser Rendering. Trade-offs: no video playback, no WebGL, limited persistent-auth support.
 - [Browser Use](https://github.com/browser-use/browser-use) - **v0.13.7 (July 27, 2026)**. Make websites accessible for AI agents with browser automation. The de-facto open-source choice in 2026, 109K+ stars. ![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fbrowser-use%2Fbrowser-use&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
 - [Stagehand](https://github.com/browserbase/stagehand) - The SDK for browser agents — typed `act`/`extract`/`observe` primitives over Playwright by Browserbase. MIT. ![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fbrowserbase%2Fstagehand&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
@@ -2191,5 +2192,3 @@ Made with ❤️ by [Zijian Ni](https://github.com/Zijian-Ni)
 *Last updated: August 15, 2026*
 
 </div>
-
-

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -982,6 +982,7 @@
 
 *真实浏览器中工作的 Agent —— 导航、点击、抓取、跨页流程。*
 
+- [agent-qa](https://github.com/vostride/agent-qa) - 开源自我改进型 QA Agent，可执行自然语言描述的 Web 与移动端测试，自愈 UI 交互，并从历史运行中学习。![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fvostride%2Fagent-qa&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
 - [Cloudflare Kitesurf](https://blog.cloudflare.com/kitesurf/) - 🆕 ⚡ **2026-08-06（beta，Cloudflare Agents Week）**。Cloudflare 专为 AI Agent 打造的无服务器浏览器，运行于 Workers 上，每次会话独立隔离、无状态，优先优化 token 数与上下文窗口效率而非像素级渲染。支持 Puppeteer 和 Playwright；截图类负载 **CPU 消耗为 Chromium 的 1/3.1、内存为 1/4.7**，通过 215K+ 项 Web Platform Tests。beta 期间通过 Browser Rendering 免费使用。限制：不支持视频播放、WebGL 和持久登录。
 - [Browser Use](https://github.com/browser-use/browser-use) - **v0.13.7（2026-07-27）**。2026 年开源浏览器 Agent 事实标准。109K+ star。![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fbrowser-use%2Fbrowser-use&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)
 - [Stagehand](https://github.com/browserbase/stagehand) - Browserbase 出品的"浏览器 Agent SDK"：类型化 `act / extract / observe`，跑在 Playwright 上。MIT。![GitHub stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.stargazers_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fbrowserbase%2Fstagehand&color=yellow&logo=github&logoColor=white&style=flat&cacheSeconds=300)


### PR DESCRIPTION
## What does this PR add / change?

Adds agent-qa, an open-source self-improving QA agent for natural-language web and mobile testing, to Browser and Web Agents in all three maintained README languages.

## Quality checklist

- [x] The project is publicly accessible at the linked URL.
- [x] At least one of:
  - [x] 100+ GitHub stars: 764 at submission time.
  - [ ] Documented third-party adoption / production users.
  - [x] Official artefact.
- [x] I am not the sole maintainer of the project I am submitting. This is disclosed as a project-side submission rather than an independent nomination.
- [x] The description is one factual sentence with no superlatives.
- [x] No benchmark, investment, or release-date claim is included.
- [x] The entry is placed first in the section for alphabetical ordering.

## Independent traction

1. 764 public GitHub stars.
2. 3,251 npm downloads for agent-qa from 2026-07-11 through 2026-08-09, from the npm downloads API.
3. Published npm package agent-qa version 0.1.21 with public docs and repository metadata.

## Validation

- scripts/check_markdown.py: clean for English, Simplified Chinese, and Japanese.
- scripts/sync_audit.py --summary: all three READMEs remain fully in sync.
- Project and dynamic star-badge URLs return HTTP 200.

## Related submissions

- [x] Yes. Related submissions made today for transparency: chaosync-org/awesome-ai-agent-testing#23, Samuray49/awesome-ai-agent-testing#1, furudo-erika/awesome-ai-testing-tools#3, ZJU-REAL/Awesome-GUI-Agents#13, tensorchord/Awesome-LLMOps#753, and filipecalegario/awesome-generative-ai#666. Additional relevant list submissions may be made as part of the same campaign.