### PR TITLE
Add sofagent to Agent Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,6 +1581,7 @@ Entries may carry one or more status tags so readers can judge maturity at a gla
 | [Prompt Armor](https://promptarmor.com/) | ❌ | ⭐⭐⭐⭐☆ | ✅ | ❌ | Proprietary |
 | [Azure AI Content Safety](https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety) | ❌ | ✅ | ✅ | ❌ (Azure) | Proprietary |
 | [Rebuff](https://github.com/protectai/rebuff) | ❌ | ⭐⭐⭐⭐☆ | ❌ | ✅ | MIT |
+| [sofagent](https://github.com/KongFangXun/sofagent) | ❌ | ✅ | ✅ (HMAC-chained) | ✅ | MIT |
 
 ---
 


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to the **🛡️ Agent Security Tools** table (row after Rebuff).

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is an MIT-licensed, self-hostable commit-time audit harness for AI coding agents: 24 git-diff rules enforced as a git hook, HMAC-chained audit logs, and snapshot rollback. It blocks credential leaks and out-of-scope file changes before a commit lands. Also available as an MCP server with 80+ tools. Sources for claims: [README](https://github.com/KongFangXun/sofagent#readme) (rule count and mechanism are verifiable in-repo).

Related listings: [awesome-dsh-plugin #4101 (merged)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/4101) · [punkpeye/awesome-mcp-servers #13312](https://github.com/punkpeye/awesome-mcp-servers/pull/13312) · [agentrust-io/awesome-ai-governance #89 (merged)](https://github.com/agentrust-io/awesome-ai-governance/pull/89)

Single table-row addition to README.md only.

